### PR TITLE
PHP Fatal error (in login.php)

### DIFF
--- a/var/www/html/supermon/login.php
+++ b/var/www/html/supermon/login.php
@@ -39,7 +39,7 @@ function crypt_apr1_md5($plainpasswd, $saltstr = null)
         $text .= substr($bin, 0, min(16, $i));
     }
     for ($i = $len; $i > 0; $i >>= 1) {
-        $text .= ($i & 1) ? chr(0) : $plainpasswd{0};
+        $text .= ($i & 1) ? chr(0) : $plainpasswd[0];
     }
     $bin = pack("H32", md5($text));
     for ($i = 0; $i < 1000; $i++) {


### PR DESCRIPTION
In PHP, using array and string offset access syntax with curly braces was deprecated as of PHP 7.4.  This deprecation became a fatal error in the latest version(s) of PHP.

The fix is to use square brackets to access array elements or string characters instead of using curly braces